### PR TITLE
remove accent for XML compatibility

### DIFF
--- a/integron_finder
+++ b/integron_finder
@@ -1416,7 +1416,7 @@ or define INTEGRON_HOME environment variable.""")
 Python {1}
 
  - open-source GPLv3,
- - Jean Cury, Betrand Néron, Eduardo Rocha,
+ - Jean Cury, Bertrand Neron, Eduardo Rocha,
  - citation:
 
  Identification and analysis of integrons and cassette arrays in bacterial genomes


### PR DESCRIPTION
I had the following error `ValueError: All strings must be XML compatible: Unicode or ASCII, no NULL bytes or control characters` due to the accent in the version text.
Thanks !