### PR TITLE
Small change to keep it up with the matplot version

### DIFF
--- a/integron_finder
+++ b/integron_finder
@@ -486,7 +486,7 @@ class Integron(object):
         ax.set_xlim(xlims)
         fig.subplots_adjust(left=0.05, right=0.80)
         ax.hlines(0, ax.get_xlim()[0], ax.get_xlim()[1], "lightgrey", "--")
-        ax.grid("on", "major", axis="x")
+        ax.grid(True, "major", axis="x")
         ax.set_ylim(-4, 4)
         ax.get_yaxis().set_visible(False)
         if file != 0:


### PR DESCRIPTION
Avoid this warning:
/usr/lib64/python2.7/site-packages/matplotlib/cbook/deprecation.py:107: MatplotlibDeprecationWarning: Passing one of 'on', 'true', 'off', 'false' as a boolean is deprecated; use an actual boolean (True/False) instead.
  warnings.warn(message, mplDeprecation, stacklevel=1)

Not sure if it will be compatible with older versions of matplotlib